### PR TITLE
Fix broken resource URI under Windows

### DIFF
--- a/lib/src/template_file.dart
+++ b/lib/src/template_file.dart
@@ -22,10 +22,14 @@ class TemplateFile {
 
   /// Renders template file on [_path] with values from [_data].
   Future<String> renderString() async {
-    var resource = new Resource('package:angular_cli/templates/$_path');
+    var uri = _toUri('package:angular_cli/templates/$_path');
+    var resource = new Resource(uri);
     var content = await resource.readAsString(encoding: UTF8);
 
     var template = new Template(content);
     return template.renderString(_data);
   }
+
+  // Convert (windows) path into resource URI.
+  String _toUri(String path) => path.replaceAll('\\', '/');
 }


### PR DESCRIPTION
Fixes an exception under Windows calling `ngdart new test_project`

```
Unhandled exception:
Unsupported operation: Illegal character in path
#0      _Uri._checkWindowsPathReservedCharacters (dart:core/uri.dart:1697)
#1      _Uri._toWindowsFilePath (dart:core/uri.dart:2626)
#2      _Uri.toFilePath (dart:core/uri.dart:2601)
#3      new File.fromUri (dart:io/file.dart:229)
#4      readAsString (package:resource/src/io_io.dart:62:16)
<asynchronous suspension>
#5      DefaultLoader.readAsString (package:resource/src/resource_loader.dart:69:7)
#6      Resource.readAsString (package:resource/src/resource.dart:74:20)
<asynchronous suspension>
#7      TemplateFile.renderString (package:angular_cli/src/template_file.dart:26:34)
<asynchronous suspension>
#8      Generator.renderAndWriteTemplates (package:angular_cli/src/generator.dart:23:62)
<asynchronous suspension>
#9      ProjectGenerator.generate (package:angular_cli/src/generators/project.dart:61:11)
<asynchronous suspension>
#10     NewProjectCommand.run (package:angular_cli/src/commands/new.dart:41:10)
<asynchronous suspension>
#11     CommandRunner.runCommand (package:args/command_runner.dart:194:27)
<asynchronous suspension>
#12     NgDartCommanderRunner.run (package:angular_cli/src/command_runner.dart:33:11)
<asynchronous suspension>
#13     main (file:///c:/Users/danie/Documents/GitHub/angular_cli/bin/ngdart.dart:17:18)
<asynchronous suspension>
#14     _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:263)
#15     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:151)
Exited (255)
```